### PR TITLE
[FIX] Adjust Margin for `Docs` Nav Item

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -826,6 +826,10 @@ body,
   }
 }
 
+.p-menubar:not(.p-menubar-mobile) .p-menubar-root-list > .p-menuitem {
+  margin: 0 !important;
+}
+
 .p-button {
   background-color: theme("colors.primary.600");
   border-color: theme("colors.primary.600");


### PR DESCRIPTION
It has been annoying me for a couple weeks now 😅

Just a small tweak to CSS to make the `docs` navbar item inline with the other two.

Before:
<img width="1003" height="156" alt="before" src="https://github.com/user-attachments/assets/8aa441ab-3571-4a76-b72a-1bdb3c8eff12" />

After:
<img width="1098" height="163" alt="after" src="https://github.com/user-attachments/assets/9ffd0f91-8f20-4bb0-9835-b7317fc235cc" />

