### PR TITLE
Strip the chrome and let the page breathe

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -26,9 +26,6 @@
     --grid: 30 36 52;
     --cream: 237 230 214;
     --muted: 141 149 171;
-    /* Faint label text (text-grid), decoupled from the grid line color so it
-       can stay legible independently of borders/backgrounds. */
-    --grid-text: 30 36 52;
 
     /* Default body text (was text-zinc-300). */
     --body-fg: 212 212 216;
@@ -60,8 +57,6 @@
     --cream: 43 39 33;
     /* Darker than before so secondary text reads clearly on cream. */
     --muted: 82 74 60;
-    /* Faint label tone — a touch lighter than muted. */
-    --grid-text: 138 130 111;
 
     --body-fg: 68 62 51;
   }
@@ -125,9 +120,13 @@
     align-items: center;
     justify-content: center;
     gap: 0.625rem;
-    padding: 0.9375rem 1.75rem;
+    /* Fixed height, not min-height: a label that falls back to another font for
+       a glyph (↗) builds a taller line box than pure Silkscreen, which used to
+       make the secondary button outgrow the primary one sitting next to it. */
+    height: 3rem;
+    padding: 0 1.375rem;
     font-family: "Silkscreen", "Space Mono", ui-monospace, monospace;
-    font-size: 0.8125rem;
+    font-size: 0.875rem;
     line-height: 1;
     letter-spacing: 0.1em;
     text-transform: uppercase;
@@ -376,12 +375,6 @@
 }
 
 @layer utilities {
-  /* text-grid is a faint *text* tone, decoupled from the `grid` line color used
-     by borders/backgrounds so it can stay legible in light mode. */
-  .text-grid {
-    color: rgb(var(--grid-text) / var(--tw-text-opacity, 1));
-  }
-
   .blink {
     animation: blink 1.1s steps(2, start) infinite;
   }

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -375,6 +375,20 @@
 }
 
 @layer utilities {
+  /* Melts the hero art into the page at the sides and bottom. Two masks are
+     intersected so the horizontal and vertical fades multiply rather than
+     replace one another. */
+  .hero-fade {
+    -webkit-mask-image:
+      linear-gradient(90deg, transparent, black 20%, black 80%, transparent),
+      linear-gradient(180deg, black 90%, transparent);
+    mask-image:
+      linear-gradient(90deg, transparent, black 20%, black 80%, transparent),
+      linear-gradient(180deg, black 90%, transparent);
+    -webkit-mask-composite: source-in;
+    mask-composite: intersect;
+  }
+
   .blink {
     animation: blink 1.1s steps(2, start) infinite;
   }

--- a/components/AppConsole.vue
+++ b/components/AppConsole.vue
@@ -70,7 +70,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <RetroWindow title="DEVICE_SELECT.EXE">
+  <div class="flex flex-col">
     <div
       class="grid lg:grid-cols-[20rem_1fr]"
       @mouseenter="hovered = true"
@@ -128,7 +128,7 @@ onMounted(() => {
             </span>
             <span
               class="mt-1 block font-mono text-[9px] uppercase tracking-[0.25em]"
-              :class="i === active ? 'text-primary-300' : 'text-grid'"
+              :class="i === active ? 'text-primary-300' : 'text-muted'"
             >
               {{ item.system }}
             </span>
@@ -144,7 +144,7 @@ onMounted(() => {
         <!-- filler slot, wink at empty cartridge bays -->
         <div
           aria-hidden="true"
-          class="hidden flex-1 items-center justify-center gap-3 px-5 py-5 font-mono text-[10px] uppercase tracking-[0.3em] text-grid lg:flex"
+          class="hidden flex-1 items-center justify-center gap-3 px-5 py-5 font-mono text-[10px] uppercase tracking-[0.3em] text-muted lg:flex"
         >
           Empty slot
         </div>
@@ -221,7 +221,10 @@ onMounted(() => {
               rel="noopener"
               class="mt-auto inline-block self-start pt-8"
             >
-              <span class="btn-pixel">{{ app.ctaText }} ↗</span>
+              <span class="btn-pixel">
+                {{ app.ctaText }}
+                <span aria-hidden="true">↗</span>
+              </span>
             </a>
           </div>
         </div>
@@ -244,7 +247,7 @@ onMounted(() => {
         }}<span class="blink text-primary-400">_</span>
       </span>
     </div>
-  </RetroWindow>
+  </div>
 </template>
 
 <style scoped>

--- a/components/AppConsole.vue
+++ b/components/AppConsole.vue
@@ -242,10 +242,7 @@ onMounted(() => {
           <span class="text-primary-300">🖱</span> Click screen to zoom
         </span>
       </span>
-      <span aria-hidden="true">
-        Slot {{ active + 1 }}/{{ apps.length
-        }}<span class="blink text-primary-400">_</span>
-      </span>
+      <span aria-hidden="true"> Slot {{ active + 1 }}/{{ apps.length }} </span>
     </div>
   </div>
 </template>

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -59,20 +59,20 @@ const navItems = [
         </a>
       </div>
 
-      <div class="hidden items-center gap-8 md:flex">
+      <div class="hidden items-center gap-9 md:flex">
         <a
           v-for="item in navItems"
           :key="item.label"
           :href="item.href"
           target="_blank"
           rel="noopener"
-          class="font-mono text-xs uppercase tracking-[0.2em] transition-colors hover:text-cream"
+          class="font-mono text-sm font-medium capitalize tracking-[0.2em] transition-colors hover:text-cream"
         >
           {{ item.label }}
         </a>
       </div>
 
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-1">
         <button
           type="button"
           :title="
@@ -81,7 +81,7 @@ const navItems = [
           :aria-label="
             theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'
           "
-          class="flex h-9 w-9 items-center justify-center border border-grid text-cream transition-colors hover:border-primary-400 hover:text-primary-300"
+          class="flex h-9 w-9 items-center justify-center text-cream transition-colors hover:text-primary-300"
           @click="toggleTheme"
         >
           <FontAwesomeIcon
@@ -94,7 +94,7 @@ const navItems = [
           target="_blank"
           rel="noopener"
           title="Support the project"
-          class="hidden h-9 w-9 items-center justify-center border border-grid transition-colors hover:border-primary-400 hover:text-primary-300 sm:flex"
+          class="hidden h-9 w-9 items-center justify-center transition-colors hover:text-primary-300 sm:flex"
         >
           <FontAwesomeIcon :icon="faHeart" class="h-3.5" />
         </a>
@@ -103,7 +103,7 @@ const navItems = [
           target="_blank"
           rel="noopener"
           title="Join the Discord"
-          class="hidden h-9 w-9 items-center justify-center border border-grid transition-colors hover:border-primary-400 hover:text-primary-300 sm:flex"
+          class="hidden h-9 w-9 items-center justify-center transition-colors hover:text-primary-300 sm:flex"
         >
           <FontAwesomeIcon :icon="faDiscord" class="h-3.5" />
         </a>
@@ -112,14 +112,14 @@ const navItems = [
           target="_blank"
           rel="noopener"
           title="GitHub repository"
-          class="flex h-9 items-center gap-2 border border-grid px-3 font-mono text-xs text-cream transition-colors hover:border-primary-400 hover:text-primary-300"
+          class="ml-1 flex h-9 items-center gap-2 px-3 font-mono text-xs text-cream transition-colors hover:text-primary-300"
         >
           <FontAwesomeIcon :icon="faGithub" class="h-4" />
           <span>{{ (githubStars / 1000).toFixed(1) }}K</span>
         </a>
         <button
           type="button"
-          class="flex h-9 w-9 items-center justify-center border border-grid text-cream md:hidden"
+          class="flex h-9 w-9 items-center justify-center text-cream md:hidden"
           aria-label="Toggle menu"
           @click="menuOpen = !menuOpen"
         >
@@ -138,7 +138,7 @@ const navItems = [
         :href="item.href"
         target="_blank"
         rel="noopener"
-        class="block border-b border-grid px-6 py-4 font-mono text-xs uppercase tracking-[0.2em] last:border-b-0 hover:text-cream"
+        class="block border-b border-grid px-6 py-4 font-mono text-sm font-medium capitalize tracking-[0.2em] last:border-b-0 hover:text-cream"
         @click="menuOpen = false"
       >
         {{ item.label }}

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -34,7 +34,7 @@ const navItems = [
     class="sticky top-0 z-50 border-b border-grid bg-ink-950/85 backdrop-blur-md"
   >
     <nav
-      class="mx-auto flex h-16 max-w-[88rem] items-center justify-between border-x border-grid px-4 sm:px-6"
+      class="mx-auto flex h-16 max-w-[88rem] items-center justify-between px-4 sm:px-6"
     >
       <div class="flex items-center gap-3">
         <a href="#" class="flex flex-row items-center gap-2">

--- a/components/PlatformMarquee.vue
+++ b/components/PlatformMarquee.vue
@@ -19,7 +19,7 @@ const icons = useState("platform-icons", () =>
 
 <template>
   <div
-    class="pause-on-hover [mask-image:linear-gradient(90deg,transparent,black_6%,black_94%,transparent)]"
+    class="pause-on-hover border-y border-grid [mask-image:linear-gradient(90deg,transparent,black_6%,black_94%,transparent)]"
   >
     <div class="flex overflow-hidden border-grid">
       <div

--- a/components/PlatformMarquee.vue
+++ b/components/PlatformMarquee.vue
@@ -43,7 +43,7 @@ const icons = useState("platform-icons", () =>
             decoding="async"
           />
           <span
-            class="w-full truncate text-center font-mono text-[9px] text-muted uppercase tracking-widest text-grid transition-colors duration-200 group-hover:text-primary-300"
+            class="w-full truncate text-center font-mono text-[9px] text-muted uppercase tracking-widest transition-colors duration-200 group-hover:text-primary-300"
           >
             {{ icon.name }}
           </span>

--- a/components/SectionHeading.vue
+++ b/components/SectionHeading.vue
@@ -1,9 +1,5 @@
 <script setup lang="ts">
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { faGamepad } from "@fortawesome/free-solid-svg-icons";
-
 defineProps<{
-  label: string;
   title: string;
   subtitle?: string;
 }>();
@@ -11,15 +7,8 @@ defineProps<{
 
 <template>
   <div>
-    <div
-      class="flex items-center gap-3 font-mono text-xs uppercase tracking-[0.3em] text-primary-400"
-    >
-      <span>{{ label }}</span>
-      <span aria-hidden="true" class="h-px flex-1 bg-grid" />
-      <FontAwesomeIcon :icon="faGamepad" class="text-grid" size="lg" />
-    </div>
     <h2
-      class="mt-6 font-pixel text-2xl uppercase leading-snug text-cream sm:text-3xl md:text-4xl"
+      class="font-pixel text-2xl uppercase leading-snug text-cream sm:text-3xl md:text-4xl"
     >
       {{ title }}
     </h2>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -295,7 +295,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
 
     <main class="mx-auto max-w-[88rem]">
       <!-- ============================== HERO ============================== -->
-      <section class="relative overflow-hidden border-b border-grid">
+      <section class="relative overflow-hidden">
         <img
           aria-hidden="true"
           alt=""
@@ -352,9 +352,9 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       </section>
 
       <!-- ======================= SUPPORTED PLATFORMS ======================= -->
-      <section class="border-b border-grid">
+      <section class="mt-16">
         <div
-          class="flex items-center justify-between gap-4 border-b border-grid px-6 py-3 font-mono text-[10px] capitalize tracking-[0.3em] text-muted"
+          class="flex items-center justify-between gap-4 px-6 py-3 font-mono text-[10px] capitalize tracking-[0.3em] text-muted"
         >
           <span>400+ Supported Platforms</span>
           <span aria-hidden="true" class="hidden sm:block">
@@ -365,10 +365,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       </section>
 
       <!-- ============================ FEATURES ============================ -->
-      <section
-        id="features"
-        class="border-b border-grid px-6 py-16 sm:px-10 lg:px-16"
-      >
+      <section id="features" class="px-4 py-16">
         <SectionHeading
           title="Every playthrough tells a story"
           subtitle="The most powerful all-in-one app for managing and playing your retro game collection."
@@ -477,14 +474,16 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
         </div>
       </section>
 
-      <!-- ========================= PLATFORM STRIP ========================= -->
-      <section class="border-b border-grid">
+      <!-- ============================ OS STRIP ============================ -->
+      <section>
         <div
-          class="flex items-center justify-between gap-4 border-b border-grid px-6 py-3 font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
+          class="flex items-center justify-between gap-4 px-6 py-3 font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
         >
           <span>Available on every major platform and operating system</span>
         </div>
-        <div class="pause-on-hover flex overflow-hidden">
+        <div
+          class="pause-on-hover flex overflow-hidden border-y border-grid [mask-image:linear-gradient(90deg,transparent,black_6%,black_94%,transparent)]"
+        >
           <div
             v-for="copy in 2"
             :key="copy"
@@ -513,7 +512,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       </section>
 
       <!-- ============================== APPS ============================== -->
-      <section id="apps" class="border-grid px-6 pt-16 sm:px-10 lg:px-16">
+      <section id="apps" class="border-grid px-4 pt-16">
         <SectionHeading
           title="Your library on every device"
           subtitle="Native apps and integrations that bring your collection to desktops, handhelds and TVs. Pair a device in seconds with a QR code, and your saves follow you everywhere."
@@ -567,7 +566,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       </section>
 
       <!-- =========================== COMMUNITY =========================== -->
-      <section class="relative overflow-hidden border-b border-grid">
+      <section class="relative overflow-hidden">
         <GlyphField />
         <div
           aria-hidden="true"
@@ -612,199 +611,183 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
           </div>
         </div>
       </section>
-
-      <!-- ============================= FOOTER ============================= -->
-      <footer>
-        <div class="grid gap-px bg-grid sm:grid-cols-2 lg:grid-cols-4">
-          <div class="bg-ink-950 p-8">
-            <h4
-              class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
-            >
-              Project
-            </h4>
-            <ul class="mt-4 space-y-2 text-sm">
-              <li>
-                <a
-                  href="https://docs.romm.app"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Documentation</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://docs.romm.app/latest/getting-started/quick-start/"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Quick start</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://demo.romm.app"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Live demo</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://github.com/rommapp/romm"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >GitHub</a
-                >
-              </li>
-            </ul>
-          </div>
-          <div class="bg-ink-950 p-8">
-            <h4
-              class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
-            >
-              Apps
-            </h4>
-            <ul class="mt-4 space-y-2 text-sm">
-              <li>
-                <a
-                  href="https://github.com/rommapp/playnite-plugin"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Playnite plugin</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://github.com/rommapp/argosy-launcher"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Argosy launcher</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://grout.romm.app"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Grout</a
-                >
-              </li>
-            </ul>
-          </div>
-          <div class="bg-ink-950 p-8">
-            <h4
-              class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
-            >
-              Ecosystem
-            </h4>
-            <ul class="mt-4 space-y-2 text-sm">
-              <li>
-                <a
-                  href="https://docs.romm.app/latest/platforms/supported-platforms/"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Supported platforms</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://docs.romm.app/latest/getting-started/metadata-providers/"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Metadata providers</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://docs.romm.app/latest/ecosystem/feed-clients/"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Feed clients</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://docs.romm.app/latest/developers/api-reference/"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >API reference</a
-                >
-              </li>
-            </ul>
-          </div>
-          <div class="bg-ink-950 p-8">
-            <h4
-              class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
-            >
-              Community
-            </h4>
-            <ul class="mt-4 space-y-2 text-sm">
-              <li>
-                <a
-                  href="https://discord.gg/RGPJHNMMwJ"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Discord</a
-                >
-              </li>
-              <li>
-                <a
-                  href="https://opencollective.com/romm"
-                  target="_blank"
-                  rel="noopener"
-                  class="transition-colors hover:text-primary-300"
-                  >Open Collective</a
-                >
-              </li>
-              <li>
-                <a
-                  href="mailto:contact@romm.app"
-                  class="transition-colors hover:text-primary-300"
-                  >Contact</a
-                >
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <div
-          class="flex flex-wrap items-center justify-between gap-4 border-t border-grid px-6 py-4 font-mono text-[10px] uppercase tracking-[0.2em] text-muted"
-        >
-          <span>Your collection, perfected.</span>
-          <span class="hidden md:block">© The RomM Project · AGPL-3.0</span>
-          <span
-            aria-label="Secured with Aikido"
-            class="bevel-out inline-flex items-stretch border border-grid font-mono text-[10px] uppercase tracking-[0.2em]"
-          >
-            <span
-              class="flex items-center gap-1.5 bg-ink-800 px-2.5 py-1 text-muted"
-            >
-              <FontAwesomeIcon
-                :icon="faShieldHeart"
-                class="h-2.5 text-primary-400"
-              />
-              Secured with
-            </span>
-            <span
-              class="flex items-center bg-primary-500 px-2.5 py-1 font-bold text-ink-950"
-            >
-              Aikido
-            </span>
-          </span>
-        </div>
-      </footer>
     </main>
+
+    <!-- ============================= FOOTER ============================= -->
+    <footer>
+      <div class="mx-auto grid max-w-[88rem] sm:grid-cols-2 lg:grid-cols-4">
+        <div class="bg-ink-950 p-8">
+          <h4
+            class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
+          >
+            Project
+          </h4>
+          <ul class="mt-4 space-y-2 text-sm">
+            <li>
+              <a
+                href="https://docs.romm.app"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Documentation</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://docs.romm.app/latest/getting-started/quick-start/"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Quick start</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://demo.romm.app"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Live demo</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://github.com/rommapp/romm"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >GitHub</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="bg-ink-950 p-8">
+          <h4
+            class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
+          >
+            Apps
+          </h4>
+          <ul class="mt-4 space-y-2 text-sm">
+            <li>
+              <a
+                href="https://github.com/rommapp/playnite-plugin"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Playnite plugin</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://github.com/rommapp/argosy-launcher"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Argosy launcher</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://grout.romm.app"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Grout</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="bg-ink-950 p-8">
+          <h4
+            class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
+          >
+            Ecosystem
+          </h4>
+          <ul class="mt-4 space-y-2 text-sm">
+            <li>
+              <a
+                href="https://docs.romm.app/latest/platforms/supported-platforms/"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Supported platforms</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://docs.romm.app/latest/getting-started/metadata-providers/"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Metadata providers</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://docs.romm.app/latest/ecosystem/feed-clients/"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Feed clients</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://docs.romm.app/latest/developers/api-reference/"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >API reference</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="bg-ink-950 p-8">
+          <h4
+            class="font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
+          >
+            Community
+          </h4>
+          <ul class="mt-4 space-y-2 text-sm">
+            <li>
+              <a
+                href="https://discord.gg/RGPJHNMMwJ"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Discord</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://opencollective.com/romm"
+                target="_blank"
+                rel="noopener"
+                class="transition-colors hover:text-primary-300"
+                >Open Collective</a
+              >
+            </li>
+            <li>
+              <a
+                href="mailto:contact@romm.app"
+                class="transition-colors hover:text-primary-300"
+                >Contact</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Full-bleed rule: the bar spans the viewport, its text stays on the
+           88rem page grid. -->
+      <div class="border-t border-grid">
+        <div
+          class="mx-auto flex max-w-[88rem] flex-wrap items-center justify-center gap-4 px-6 py-4 font-mono text-[10px] uppercase tracking-[0.2em] text-muted"
+        >
+          <span>© The RomM Project · AGPL-3.0</span>
+        </div>
+      </div>
+    </footer>
 
     <!-- ============================ LIGHTBOX ============================ -->
     <Teleport to="body">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -304,21 +304,22 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
             /images/blocks/v5/collection.png    1x,
             /images/blocks/v5/collection@2x.png 2x
           "
-          class="absolute inset-0 h-full w-full object-cover object-top opacity-75"
+          class="hero-fade absolute inset-0 h-full w-full object-cover object-top opacity-75"
           fetchpriority="high"
         />
         <div
           aria-hidden="true"
           class="absolute inset-0 bg-gradient-to-b from-ink-950/80 via-ink-950/70 to-ink-950"
         />
-        <div aria-hidden="true" class="dot-grid absolute inset-0" />
         <div
           aria-hidden="true"
           class="absolute -top-48 left-1/2 h-[38rem] w-[64rem] max-w-none -translate-x-1/2 rounded-full bg-primary-500/10 blur-[120px]"
         />
-        <div aria-hidden="true" class="scanlines absolute inset-0" />
+        <div aria-hidden="true" class="hero-fade scanlines absolute inset-0" />
 
-        <div class="relative z-10 px-6 py-32 text-center sm:px-10 lg:px-16">
+        <div
+          class="relative z-10 px-6 pb-36 pt-32 text-center sm:px-10 lg:px-16"
+        >
           <h1
             class="mx-auto font-pixel text-3xl uppercase leading-tight text-cream sm:text-4xl md:text-5xl xl:text-6xl"
           >
@@ -352,11 +353,11 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       </section>
 
       <!-- ======================= SUPPORTED PLATFORMS ======================= -->
-      <section class="mt-16">
+      <section class="mt-8">
         <div
-          class="flex items-center justify-between gap-4 px-6 py-3 font-mono text-[10px] capitalize tracking-[0.3em] text-muted"
+          class="flex items-center justify-between gap-4 px-6 py-3 font-mono text-[10px] tracking-[0.3em] text-muted"
         >
-          <span>400+ Supported Platforms</span>
+          <span>400+ supported platforms</span>
           <span aria-hidden="true" class="hidden sm:block">
             Consoles • Handhelds • Computers • Arcade
           </span>
@@ -373,7 +374,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
 
         <!-- Bento feature grid -->
         <div
-          class="mt-12 grid auto-rows-fr gap-px border border-grid bg-grid sm:grid-cols-2 lg:grid-cols-4"
+          class="mt-6 grid auto-rows-fr gap-px overflow-hidden rounded-sm border border-grid bg-grid sm:grid-cols-2 lg:grid-cols-4"
         >
           <a
             v-for="feature in FEATURES"
@@ -477,7 +478,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       <!-- ============================ OS STRIP ============================ -->
       <section>
         <div
-          class="flex items-center justify-between gap-4 px-6 py-3 font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
+          class="flex items-center justify-between gap-4 px-6 py-3 font-mono text-[10px] tracking-[0.3em] text-muted"
         >
           <span>Available on every major platform and operating system</span>
         </div>
@@ -517,15 +518,15 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
           title="Your library on every device"
           subtitle="Native apps and integrations that bring your collection to desktops, handhelds and TVs. Pair a device in seconds with a QR code, and your saves follow you everywhere."
         />
+
+        <div class="mt-6 overflow-hidden rounded-sm border border-grid">
+          <AppConsole :apps="APPS" @select="selectedImage = $event" />
+        </div>
       </section>
 
-      <div class="mt-16 border-y border-grid">
-        <AppConsole :apps="APPS" @select="selectedImage = $event" />
-      </div>
-
       <!-- ============================= STATS ============================= -->
-      <section class="border-b border-grid">
-        <div class="grid grid-cols-2 gap-px bg-grid lg:grid-cols-4">
+      <section class="mt-16">
+        <div class="grid grid-cols-2 lg:grid-cols-4">
           <div class="bg-ink-950 p-4 text-center">
             <div class="font-pixel text-2xl text-cream md:text-4xl">
               {{ githubStars.toLocaleString() }}
@@ -566,7 +567,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       </section>
 
       <!-- =========================== COMMUNITY =========================== -->
-      <section class="relative overflow-hidden">
+      <section class="relative overflow-hidden py-16">
         <GlyphField />
         <div
           aria-hidden="true"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -256,7 +256,7 @@ const FEATURE_GLYPH: Record<string, string> = {
   small: "text-[6rem] -bottom-5 -right-4",
 };
 
-const githubStars = ref<number>(3_800);
+const githubStars = ref<number>(11_000);
 const discordMembers = ref<number>(3_000);
 const selectedImage = ref<AppImage | undefined>(undefined);
 
@@ -293,7 +293,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
   <div>
     <AppHeader :githubStars="githubStars" />
 
-    <main class="mx-auto max-w-[88rem] border-x border-grid">
+    <main class="mx-auto max-w-[88rem]">
       <!-- ============================== HERO ============================== -->
       <section class="relative overflow-hidden border-b border-grid">
         <img
@@ -318,34 +318,15 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
         />
         <div aria-hidden="true" class="scanlines absolute inset-0" />
 
-        <div class="relative z-10 px-6 py-24 text-center sm:px-10 lg:px-16">
-          <div class="flex flex-wrap items-center justify-center gap-3">
-            <div
-              class="inline-flex items-center gap-3 border border-grid bg-ink-900/90 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.25em]"
-            >
-              Self-hosted rom manager
-            </div>
-            <a
-              href="https://github.com/rommapp/romm/releases/tag/5.0.0"
-              target="_blank"
-              rel="noopener"
-              class="inline-flex items-center gap-2 border border-primary-500/40 bg-primary-100/80 dark:bg-primary-900/80 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.25em] transition-colors hover:border-primary-400"
-            >
-              <span class="bg-primary-500 px-1.5 font-bold text-ink-950">
-                New
-              </span>
-              RomM 5.0 is out ↗
-            </a>
-          </div>
-
+        <div class="relative z-10 px-6 py-32 text-center sm:px-10 lg:px-16">
           <h1
-            class="mx-auto mt-10 font-pixel text-3xl uppercase leading-tight text-cream sm:text-4xl md:text-5xl xl:text-6xl"
+            class="mx-auto font-pixel text-3xl uppercase leading-tight text-cream sm:text-4xl md:text-5xl xl:text-6xl"
           >
             Your collection,<br />
             <span class="text-primary-400">perfected</span>
           </h1>
 
-          <p class="mx-auto mt-8 max-w-2xl leading-relaxed">
+          <p class="mx-auto mt-8 max-w-2xl font-medium leading-relaxed">
             Scan, enrich, browse and play your ROM collection from one beautiful
             & free self-hosted app. Metadata from 10+ providers, save sync
             across your devices, and support for over 400 platforms. RomM is a
@@ -361,7 +342,10 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
               <span class="btn-pixel">Install now</span>
             </a>
             <a href="https://demo.romm.app" target="_blank" rel="noopener">
-              <span class="btn-ghost">View demo ↗</span>
+              <span class="btn-ghost">
+                View demo
+                <span aria-hidden="true">↗</span>
+              </span>
             </a>
           </div>
         </div>
@@ -370,11 +354,11 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       <!-- ======================= SUPPORTED PLATFORMS ======================= -->
       <section class="border-b border-grid">
         <div
-          class="flex items-center justify-between gap-4 border-b border-grid px-6 py-3 font-mono text-[10px] uppercase tracking-[0.3em] text-muted"
+          class="flex items-center justify-between gap-4 border-b border-grid px-6 py-3 font-mono text-[10px] capitalize tracking-[0.3em] text-muted"
         >
-          <span>400+ supported platforms</span>
-          <span aria-hidden="true" class="hidden text-grid sm:block">
-            consoles • handhelds • computers • arcade
+          <span>400+ Supported Platforms</span>
+          <span aria-hidden="true" class="hidden sm:block">
+            Consoles • Handhelds • Computers • Arcade
           </span>
         </div>
         <PlatformMarquee />
@@ -386,7 +370,6 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
         class="border-b border-grid px-6 py-16 sm:px-10 lg:px-16"
       >
         <SectionHeading
-          label="Features"
           title="Every playthrough tells a story"
           subtitle="The most powerful all-in-one app for managing and playing your retro game collection."
         />
@@ -435,7 +418,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
               </h3>
               <span
                 aria-hidden="true"
-                class="shrink-0 self-start font-mono text-[11px] text-grid transition-all duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-primary-200"
+                class="shrink-0 self-start font-mono text-[11px] text-muted transition-all duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-primary-200"
               >
                 ↗
               </span>
@@ -477,7 +460,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
             <!-- supported metadata source logos -->
             <div
               v-if="feature.sources"
-              class="relative mt-5 flex flex-wrap items-center gap-x-1"
+              class="relative mt-5 hidden flex-wrap items-center gap-x-1 sm:flex"
             >
               <img
                 v-for="source in METADATA_SOURCES"
@@ -532,7 +515,6 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       <!-- ============================== APPS ============================== -->
       <section id="apps" class="border-grid px-6 pt-16 sm:px-10 lg:px-16">
         <SectionHeading
-          label="Play anywhere"
           title="Your library on every device"
           subtitle="Native apps and integrations that bring your collection to desktops, handhelds and TVs. Pair a device in seconds with a QR code, and your saves follow you everywhere."
         />


### PR DESCRIPTION
Visual pass over the landing page. The page had accumulated a lot of framing — every header control in its own box, every section fenced by a grid rule, eyebrow labels above each heading — and it was competing with the content. This strips most of it and keeps rules only where they frame something.

## Header
- Remove the borders around the theme toggle, heart, Discord, GitHub and menu controls; the version badge keeps its box.
- Tighten the icon row to `gap-1`, nav links set in capitalized 14px medium.
- Drop the `border-x` so nothing draws vertical rules at the container edges.

## Hero
- Remove the "Self-hosted rom manager" chip and the "RomM 5.0 is out" release link.
- Mask the artwork and its scanline overlay so they dissolve at the sides and bottom instead of stopping on hard lines, and drop the dot-matrix layer that was competing with the art.
- CTAs get a fixed height so a fallback glyph can no longer build a taller line box than its neighbour — "View demo ↗" used to sit a few px taller than "Install now" because `↗` isn't in Silkscreen. The arrow now lives in its own flex item.

## Sections
- Remove the section borders throughout; the two scrolling strips keep `border-y` and both now use the same edge mask.
- Pull headings closer to what they introduce (`mt-6`), drop the eyebrow label rows from `SectionHeading` entirely.
- Move `<footer>` outside `<main>` so its rule spans the viewport while its content stays on the 88rem grid.
- Replace `text-grid` with `text-muted` everywhere and delete the utility and its variable.

Also: GitHub stars fallback bumped to 11k, metadata source logos hidden below `sm`, and the Aikido badge plus tagline removed from the footer.

Note: `components/RetroWindow.vue` is now unused — it only wrapped the apps console to draw the `DEVICE_SELECT.EXE` title bar. Left in place rather than deleted; say the word either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)